### PR TITLE
#17 - Update class name for the partners and sponsors section

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -39,7 +39,7 @@ links: [[href: "#about-us", text: "About Us"], [href: "#", text: "Join Our Maili
   </div>
   
   <!-- Sponsors and Partners -->
-  <div id="partners-sponsors" class="featured-sponsors container text-center padding-top-30 padding-bottom-40">
+  <div id="partners-sponsors" class="featured-partners container text-center padding-top-30 padding-bottom-40">
     <h2 class="header-underline">Sponsors</h2>
     {{< sponsors >}}
     <h2 class="header-underline margin-top-60">Partners</h2>

--- a/less/styles.less
+++ b/less/styles.less
@@ -141,7 +141,7 @@ h2 {
   }
 }
 
-.featured-sponsors {
+.featured-partners {
   .header-underline:after {
     margin: 15px auto 0;
     width: 300px;


### PR DESCRIPTION
This is to prevent Ad blockers to hide the partners and sponsors section

Signed-off-by: Eric Poirier <eric.poirier@eclipse-foundation.org>