### PR TITLE
Fixed ordering of sponsors #69

### DIFF
--- a/data/sponsors.yml
+++ b/data/sponsors.yml
@@ -25,15 +25,20 @@ items:
     link: http://www.iis.ee.ethz.ch/
     img_width: 100
   -
-    image: /images/sponsors/imperas-logo.svg
-    title: Imperas
-    link: http://www.imperas.com/
-    img_width: 100
-  -
     image: /images/sponsors/greenwaves.svg
     title: Greenwaves Technologies
     link: https://greenwaves-technologies.com/
     img_width: 120
+  -
+    image: /images/sponsors/huawei-logo.png
+    title: Huawei
+    link: https://www.huawei.com
+    img_width: 135
+  -
+    image: /images/sponsors/imperas-logo.svg
+    title: Imperas
+    link: http://www.imperas.com/
+    img_width: 100
   -
     image: /images/sponsors/metrics-logo.svg
     title: Metrics
@@ -64,8 +69,3 @@ items:
     title: Thales Group
     link: https://www.thalesgroup.com/en
     img_width: 120
-  -
-    image: /images/sponsors/huawei-logo.png
-    title: Huawei
-    link: https://www.huawei.com
-    img_width: 135


### PR DESCRIPTION
Moved Imperas and Huawei sponsor logos

Change-Id: I5ab09c7d11f02a0eb4bc93095d4dd20baef15fb2
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>