### PR TITLE
Create an About us and Working Groups page #160

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,8 +47,8 @@ themesDir = "node_modules/"
   hrefTargetBlank = true
   
 [[menu.main]]
-    name = "CORE-V Family"
-    url = "/#core-v-family"
+    name = "About Us"
+    url = "/about-us"
     weight = 1
     
 [[menu.main]]
@@ -62,8 +62,8 @@ themesDir = "node_modules/"
     weight = 3
     
 [[menu.main]]
-    name = "About Us"
-    url = "/#about-us"
+    name = "Working Groups"
+    url = "/working-groups"
     weight = 3
     
 [[menu.main]]

--- a/content/about-us/_index.md
+++ b/content/about-us/_index.md
@@ -1,0 +1,8 @@
+---
+title: "About Us"
+date: 2019-05-04T10:00:45-04:00
+hide_sidebar: true
+---
+OpenHW Group is a not-for-profit, global organization driven by its members and individual contributors where hardware and software designers collaborate in the development of open-source cores, related IP, tools and software. OpenHW provides an infrastructure for hosting high quality open-source HW developments in line with industry best practices.
+
+{{< staff >}}

--- a/content/working-groups/_index.md
+++ b/content/working-groups/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Working Groups"
+date: 2019-05-03T10:00:45-04:00
+hide_sidebar: true
+---
+The OpenHW Group is a not-for-profit, global organization driven by its members and individual contributors where hardware and software designers collaborate in the development of open-source cores, related IP, tools and software. OpenHW provides an infrastructure for hosting high quality open-source HW developments in line with industry best practices. 
+
+The projects and activities within the OpenHW Group are managed by two standing committees: the [Technical Working Group](#technical-working-group) and the [Marketing Working Group](#marketing-working-group) including sub Task Groups therein.
+
+{{< working-groups >}}

--- a/data/staff.yml
+++ b/data/staff.yml
@@ -1,0 +1,59 @@
+items:
+  board:
+    title: OpenHW Group Board of Directors
+    members:
+     - name: Rob Oshana
+       position: Chairman of the Board
+       bio: |
+         <p>Rob Oshana is vice president of software engineering R&D for NXP Microcontrollers, where he leads open-source efforts across the company.  In addition to being Chairman of the Board for the OpenHW Group, Rob is also a member of the RISC-V International board of directors.  Rob is a recognized international speaker and a senior member of IEEE.  He is also an adjunct professor at Southern Methodist University and the University of Texas.</p>
+       linkedin: https://www.linkedin.com/in/robert-oshana-58a1784/
+     - name: Charlie Hauck
+       position: Treasurer
+       anchor: charlie-hauck
+       bio: |
+         <p>Charlie is CEO of Bluespec, Inc., a provider of high­-level tools and IP for ASIC and FPGA design. Before Bluespec, he was general manager of Faraday Technology USA, a fabless ASIC company. Charlie has over 25 years of experience in marketing and developing RISC processors at Lexra, LSI Logic, Kendall Square Research and Commodore. Charlie received a Bachelor of Science from Johns Hopkins University and a Master of Science from the Massachusetts Institute of Technology.</p>
+       linkedin: https://www.linkedin.com/in/charlie-hauck-5030124/
+     - name: Alessandro Piovaccari
+       position: Board Member
+       bio: |
+         <p>As Silicon Labs’ Chief Technology Officer, Alessandro Piovaccari is responsible for the company’s product and technology research and development. Alessandro joined Silicon Labs in 2003 to design the company’s single-chip FM radio products, which have surpassed 1.5 billion device shipments. He co-architected Silicon Labs’ single-chip TV tuner IC, used by nine of the world’s top ten TV makers, with more than 70 percent market share and 1 billion unit shipped.
+       linkedin: https://www.linkedin.com/in/robert-oshana-58a1784/
+     - name: Wayne Dai
+       position: Board Member
+       bio: |
+         <p>Dr. Wayne Wei-Ming Dai founded VeriSilicon in August 2001 and has served as the chairman of the board of directors, President and Chief Executive Officer since then. Prior to VeriSilicon, Dr. Dai was the Co-Chairman and Chief Technology Officer of Celestry Technologies, Inc., an EDA company, which was acquired by Cadence Design Systems in 2002. Prior to that, he was the founder, chairman of the board of directors, and Chief Executive Officer of Ultima Interconnect Technology, Inc., one of the predecessor companies to Celestry.</p>
+       linkedin: https://www.linkedin.com/in/wayne-dai-34ba3a30/
+     - name: Xiaoning Qi
+       position: Board Member
+       bio: |
+         <p>Xiaoning Qi is the Vice President of Alibaba Group and he was CEO of C-Sky Systems which was acquired by Alibaba. Previously, he held senior management and technical positions in companies such as Intel, working on integrated circuit devices, micro-processor design and platform electrical design for semiconductor systems. Additionally, he was Chairman and President of the Chinese American Semiconductor Professional Association, USA. Currently, he is a member of Asia-Pacific Leadership Council, Global Semiconductor Alliance (GSA), and member of the CEO Council, GSA. Xiaoning Qi received his Ph.D. degree in Electrical Engineering from Stanford University.</p>
+  staff:
+    title: OpenHW Group Executive Staff
+    members:
+     - name: Rick O’Connor
+       position: President & CEO
+       bio: |
+         <p>Rick O'Connor is Founder and serves as President & CEO of the OpenHW Group a not-for-profit, global organization driven by its members and individual contributors where hardware and software designers collaborate on open source cores, related IP, tools and software projects.  Previously Rick was Executive Director of the RISC-V Foundation.  Founded by Rick in 2015 with the support of over 40 Founding Members, the RISC-V Foundation currently comprises more than 400 members building an open, collaborative community of software and hardware innovators powering processor innovation. With many years of Executive level management experience in semiconductor and systems companies, Rick possesses a unique combination of business and technical skills and was responsible for the development of dozens of products accounting for over $750 million in revenue.  Rick holds an Executive MBA degree from the University of Ottawa, Canada and is an honors graduate of the faculty of Electronics Engineering Technology at Algonquin College, Canada.</p>
+       linkedin: https://www.linkedin.com/in/rickoco/
+     - name: Davide Schiavone
+       position: Staff Member
+       bio: |
+         <p>Davide is the OpenHW Group Director of Engineering, Cores Task Group and is a PhD candidate (Spring 2020) at the Integrated Systems Laboratory of ETH Zurich (Zurich, Switzerland) in the Digital Systems group Parallel Ultra Low Power (PULP) Platform under the supervision of Prof. Luca Benini.  His main research focus is on low-power energy-efficient computer architectures under the PULP project for smart systems and human-machine interfaces.  Davide’s main contributions to the PULP project have been:</p>
+         <ul>
+           <li>design of the RISC-V 32b core zero-riscy to minimize static power in always-on systems</li>
+           <li>maintaining and extending (bug fixes, verification, ISA extensions, PMP) of the RISC-V 32b core RI5CY to improve the quality, performance and features of the IP</li>
+           <li>maintaining the PULPissimo 32bit platform</li>
+           <li>implementing 3 PULPissimo-based SoC: 2 in GF22FDX and 1 in UMCL65</li>
+         </ul>
+         <p>Davide holds Bachelor and Master degrees in Computer Engineering from Politecnico di Torino, Italy.</p>
+       linkedin: https://www.linkedin.com/in/pasquale-davide-schiavone-96812758/
+     - name: Jim Parisien
+       position: Staff Member
+       bio: |
+         <p>Jim is the OpenHW Group Director of Engineering, HW & SW Task Groups.  Jim is an experienced engineer with 17+ years with System Architecture, Design, Prototyping, Test and Manufacture of digital hardware. With strong communication (written and verbal) and interpersonal skills, Jim has the ability to communicate to both technical and non-technical audiences and has managed cross functional Engineering teams, performed in various Project/Team lead roles. Jim holds a Bachelor of Science degree in Electrical Engineering from the University of Ottawa, Canada.</p>
+       linkedin: https://www.linkedin.com/in/jim-parisien-902b0b/
+     - name: Mike Thompson
+       position: Staff Member
+       bio: |
+         <p>Mike Thompson is the OpenHW Group Director of Engineering, Verification Task Group.  He is a senior IC Functional Verification engineering manager with more than 20 years experience.  Mike has led all aspects of the discipline with broad experience in simulation, emulation and prototyping plus management level experience of formal verification projects.  He has both hands-on and management level experience with multiple SV/UVM projects and has developed teams driving SV/UVM for constrained-random, coverage driven verification efforts. Michael has been involved in a dozen successful tape-outs including five 100M gate-scale devices based on proprietary RISC processors which were verified using a novel random instruction generator and coverage model implemented in SV/VMM.  Mike holds a Bachelor of Applied Science degree in Electrical and Electronics Engineering from the University of Regina, Canada.</p>
+       linkedin: https://www.linkedin.com/in/michael-thompson-0a581a/

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -1,0 +1,86 @@
+groups:
+  - name: Technical Working Group
+    description: |
+      The Technical Working Group has the mandate to drive the overall technical direction, development roadmap and project execution for all technology related activities within the OpenHW Group.  In doing so, the following sub Task Groups have been established.
+    chairs:
+      - name: Sebastian Ahmed
+        company: Silicon Laboratories
+        position: Co-chair
+        linkedin: https://www.linkedin.com/in/sebastianahmed/
+      - name: Jerry Zeng
+        company: NXP Semiconductors
+        position: Co-chair
+        linkedin: https://www.linkedin.com/in/jerry-zeng-2b2b0b3
+    task_groups:
+      - name: Cores Task Group
+        description: |
+          <p>The Cores Task Group has the mandate to develop feature and functionality roadmap and the open-source IP for the cores within the OpenHW Group such as the CORE-V Family of open-source RISC-V processors.  Existing <a href="https://www.openhwgroup.org/projects/">cores Task Group projects can be found here</a>.</p>
+        chairs:
+          - name: Arjan Bink
+            company: Silicon Laboratories
+            position: Chair
+            linkedin: https://www.linkedin.com/in/arjanbink/" class="btn btn-primary"><i class="fa fa-linkedin margin-right-10"></i>LinkedIn</a>
+          - name: Jérôme Quévremont
+            company: Thales Research & Technology
+            position: Vice Chair
+            linkedin: https://www.linkedin.com/in/j%C3%A9r%C3%B4me-qu%C3%A9vremont-245335/
+      - name: Verification Task Group
+        description: |
+          <p>The Verification Task Group has the mandate to develop best in class verification test bench environments for the cores and IP blocks developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">Verification Task Group projects can be found here</a>.</p>
+        chairs:
+          - name: Jingliang (Leo) Wang
+            company: Futurewei Technologies, Inc.
+            position: Co-chair
+            linkedin: https://www.linkedin.com/in/jingliang-leo-wang-2016b88/
+          - name: Steve Richmond
+            company: Silicon Laboratories
+            position: Co-chair
+            linkedin: https://www.linkedin.com/in/steverichmond19/
+      - name: SW Task Group
+        description: |
+          <p>The SW Task Group has the mandate to define, develop and support SW tool chain, operating system ports and firmware for the cores and IP developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">SW Task Group projects can be found here</a>.</p>
+        chairs:
+          - name: Jeremy Bennett
+            company: Embecosm
+            position: Chair
+            linkedin: https://www.linkedin.com/in/jeremypbennett/
+          - name: Yunhai Shang
+            company: Alibaba T-Head
+            position: Vice Chair
+            linkedin: http://www.linkedin.com/in/yunhai-shang/
+      - name: HW Task Group
+        description: |
+          <p>The HW Task Group has the mandate to define, develop and support SoC and FPGA based evaluation / development platforms for the cores and IP developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">HW Task Group projects can be found here</a>.</p>
+        chairs:
+          - name: Hugh Pollitt-Smith
+            company: CMC Microsystems
+            position: Chair
+            linkedin: https://www.linkedin.com/in/hugh-pollitt-smith-460aba3/
+          - name: Open
+            position: Vice Chair
+  - name: Marketing Working Group 
+    description: |
+       The Marketing Working Group has the mandate to drive positioning, promotion, training, University research initiatives and overall membership growth for the OpenHW Group. The following sub Task Group has been established to manage OpenHW Group University research initiatives:
+    chairs:
+       - name: Kevin Dobie
+         company: CMC Microsystems
+         position: Co-chair
+         linkedin: https://www.linkedin.com/in/kdobie/
+       - name: Hansheng (Hans) Tan
+         company: Futurewei Technologies, Inc.
+         position: Co-chair
+         linkedin: https://www.linkedin.com/in/hanshengtan/
+    task_groups:
+      - name: University Outreach Task Group
+        description: |
+          <p>The University Outreach Task Group has the mandate to establish industry sponsored research projects and their respective funding (with government matching) in collaboration with leading universities throughout the world.</p>
+        chairs:
+          - name: Mel Chaar
+            company: Mitacs
+            position: Co-chair
+            linkedin: https://www.linkedin.com/in/melchaar
+          - name: Hugh Pollitt-Smith
+            company: CMC Microsystems
+            position: Co-chair
+            linkedin: https://www.linkedin.com/in/hugh-pollitt-smith-460aba3/
+          

--- a/layouts/shortcodes/staff.html
+++ b/layouts/shortcodes/staff.html
@@ -1,0 +1,38 @@
+<!-- 
+  Copyright (c) 2020 Eclipse Foundation, Inc.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  Contributors:
+    Martin Lowe <martin.lowe@eclipse-foundation.org>
+
+  SPDX-License-Identifier: EPL-2.0
+-->
+<div class="staff-members">
+{{ range .Site.Data.staff.items }}
+  <div class="margin-bottom-40">
+    <h2>{{ .title }}</h2>
+    {{ range .members }}
+    {{ $anchor := urlize .anchor }}
+    {{ if not $anchor }}
+      {{ $anchor = urlize .name }}
+    {{ end }}
+    <div class="row" id="{{ $anchor }}">
+      <div class="col-xs-24">
+        <h3 style="display:inline-block;">{{ .name }}</h3><span> - <em>{{ .position }}</em></span>
+        {{ .bio | safeHTML }}
+        {{ if .linkedin }}
+        <p>
+          <a class="btn btn-primary btn-sm" href="{{ .linkedin }}" target="_blank">
+            <i class="fa fa-linkedin margin-right-10"></i>&nbsp;{{ .name }} on LinkedIn
+          </a>
+        </p>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+  </div>
+  {{ end }}
+</div>

--- a/layouts/shortcodes/working-groups.html
+++ b/layouts/shortcodes/working-groups.html
@@ -1,0 +1,64 @@
+<!-- 
+  Copyright (c) 2020 Eclipse Foundation, Inc.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  Contributors:
+    Martin Lowe <martin.lowe@eclipse-foundation.org>
+
+  SPDX-License-Identifier: EPL-2.0
+-->
+
+<div class="working-groups-container">
+  {{ range .Site.Data.working_groups.groups }}
+  <div class="working-group margin-bottom-30">
+    <h2 id="{{ .name | urlize }}">{{ .name | title }}</h2>
+    <p>{{ .description }}</p>
+    <div class="container margin-top-30 margin-bottom-30">
+      <div class="row text-center">
+        {{ range .chairs }}
+        <div class="col-xs-24 col-sm-12 match-height-item-row">
+          <p>{{ .name }}</p>
+          <p><strong>{{ .position }}</strong></p>
+          <p><em>{{ .company }}</em></p>
+          {{ if .linkedin }}
+          <p>
+            <a class="btn btn-primary btn-sm" href="{{ .linkedin }}" target="_blank">
+              <i class="fa fa-linkedin margin-right-10"></i>&nbsp;Follow {{ .name }} on LinkedIn
+            </a>
+          </p>
+          {{ end }}
+        </div>
+        {{ end }}
+      </div>
+    </div>
+    <h3>Task groups</h3>
+    {{ range .task_groups }}
+    <div class="task-group margin-bottom-20">
+      <h4 id="{{ .name | urlize }}">{{ .name | title }}</h4>
+      {{ .description | safeHTML }}
+        <div class="container margin-top-30 margin-bottom-50">
+          <div class="row text-center">
+            {{ range .chairs }}
+            <div class="col-xs-24 col-sm-12 match-height-item-row">
+              <p>{{ .name }}</p>
+              <p><strong>{{ .position }}</strong></p>
+              <p><em>{{ .company }}</em></p>
+              {{ if .linkedin }}
+              <p>
+                 <a class="btn btn-primary btn-sm" href="{{ .linkedin }}" target="_blank">
+                   <i class="fa fa-linkedin margin-right-10"></i>&nbsp;Follow {{ .name }} on LinkedIn
+                 </a>
+              </p>
+              {{ end }} 
+            </div>
+            {{ end }}
+          </div>
+        </div>
+    </div>
+    {{ end }}
+  </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
Added about us and working group pages. Added working groups and staff
shortcodes to display more advanced sections and markup. Updated
config.toml main menu with new pages.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>