### PR TITLE
News item: OpenHW TV Episode 2 register now #194

### DIFF
--- a/content/news/2020-07-01.md
+++ b/content/news/2020-07-01.md
@@ -1,0 +1,23 @@
+---
+Title: "OpenHW TV Episode 2 register now - The CORE-V family of RISC-V cores"
+date: 2020-07-01T05:10:00-00:00
+categories: ["announcements"]
+---
+
+The next episode of OpenHW TV will stream live on Thursday 16th July at 11am EST / 8am PST / 4pm BST.
+
+REGISTER HERE: https://bit.ly/2ZvxsmZ
+
+In this episode we look at highlights of the OpenHW Group CORE-V family of RISC-V cores, focusing on the CVE4 and CVA6 cores, an update of their current status within the OpenHW Group and how new contributors can participate in the development of these cores.  
+
+Following the overview there will be a live Q&A session with our panellists from the OpenHW Group experts and members:  
+
+Arjan Bink - Chair OpenHW Group Cores Task Group and Principle Architect IoT Digital Systems at Silicon Labs
+
+Jérôme Quevremont - Vice-Chair OpenHW Group Cores Task Group and RISC-V Open Hardware Project Leader at Thales
+
+JeanRoch Coulon - RISC-V Hardware and Tools Architect at Invia (Thales)
+
+Davide Schiavone - Director of Engineering (Cores Task Group) at OpenHW Group
+
+Florian Zaruba - Director of Engineering (HW & SW Task Group) at OpenHW Group


### PR DESCRIPTION
Fixes #194

URL will be /news/2020/07/01/openhw-tv-episode-2-register-now-the-core-v-family-of-risc-v-cores/

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>