### PR TITLE
Remove Wavious from the site

### DIFF
--- a/data/members.yml
+++ b/data/members.yml
@@ -308,11 +308,6 @@ types:
          link: http://www.verisilicon.com/
          img_width: 100
        -
-         image: /images/sponsors/wavious-logo.png
-         title: Wavious
-         link: https://wavious.com/
-         img_width: 120
-       -
          image: /images/sponsors/whale-microelectronics.png
          title: Hefei Whale Microelectronics
          link: 


### PR DESCRIPTION
Resolves #487 

This PR removes Wavious from the data file. It no longer renders Wavious on the site.