### PR TITLE
Add corrected content to silver membership section

### DIFF
--- a/layouts/shortcodes/membership.html
+++ b/layouts/shortcodes/membership.html
@@ -236,16 +236,12 @@
         <hr class="green margin-bottom-40 margin-top-40">
 
         <h3 class="brand-primary h4 fw-700" id="silver">Silver Member</h3>
-        <p>Associate Members are organizations that participate in and want to show support for the Eclipse
-          Foundation ecosystem. Many research and educational institutions choose to join as an Associate
-          Member. Associate membership benefits include:</p>
+        <p>Silver members contribute to the development of OpenHW Group’s global ecosystem of open-source, industrial-quality processor IP, and can participate in and contribute to all technical activities and task groups. Silver Member benefits:</p>
         <ul>
-          <li>Opportunity to join and participate on all Eclipse public mailing lists, and to attend Members
-            meetings.</li>
-          <li>Ability to join select Eclipse Working Groups as a Guest Member.</li>
-          <li>The opportunity to attend all meetings of the General Assembly.</li>
-          <li>Opportunity to show support for the Eclipse Foundation by displaying the Eclipse Foundation
-            Member logo.</li>
+            <li>Entitled to cast one vote on any matter presented to the Members (including the election of directors).</li>
+            <li>Employees are entitled to join and make technical contributions to all OpenHW Group technical committees and projects.</li>
+            <li>Entitled through their OpenHW Group and Eclipse Foundation memberships to join the OpenHW Asia and OpenHW Europe Working Groups.</li>
+            <li>Receive a complementary <a href="https://www.eclipse.org/membership/#contributing">Eclipse Foundation Contributing Membership</a>.</li>
         </ul>
         <hr class="green margin-bottom-40 margin-top-40">
 

--- a/layouts/shortcodes/membership.html
+++ b/layouts/shortcodes/membership.html
@@ -249,7 +249,7 @@
         <p>
           Supporter members show their support for OpenHW Group&apos;s global ecosystem of open-source,
           industrial-quality
-          processor IP through their active participation in all matters other than technical contribution.Supporter
+          processor IP through their active participation in all matters other than technical contribution. Supporter
           Member benefits:
         </p>
         <ul>


### PR DESCRIPTION
Resolves #495 

This PR replaces the previous content of the silver members section located at https://www.openhwgroup.org/membership/#tab-levels.

Also fixes a typo from another section.