### PR TITLE
feat(openhw-tv): Add TRISTAN workshop videos

### DIFF
--- a/content/resources/openhwtv/_index.md
+++ b/content/resources/openhwtv/_index.md
@@ -5,6 +5,8 @@ layout: single
 hide_page_title: true
 ---
 
+## Latest Season {.margin-bottom-0}
+
 {{< openhw-tv-videos displayArchive="true" >}}
 
 {{< grid/div class="margin-top-60 margin-bottom-40" >}}

--- a/content/resources/openhwtv/_index.md
+++ b/content/resources/openhwtv/_index.md
@@ -6,3 +6,9 @@ hide_page_title: true
 ---
 
 {{< openhw-tv-videos displayArchive="true" >}}
+
+{{< grid/div class="margin-top-60 margin-bottom-40" >}}
+---
+{{</ grid/div >}}
+
+{{< openhw-tv-series >}}

--- a/content/resources/openhwtv/seasons/season4.md
+++ b/content/resources/openhwtv/seasons/season4.md
@@ -1,0 +1,9 @@
+---
+title: "Season 4"
+date: 2023-08-14:00:45-04:00
+layout: single
+season: 4
+---
+
+{{< openhw-tv-videos >}}
+

--- a/content/resources/openhwtv/series/risc-v-european-summit-2023.md
+++ b/content/resources/openhwtv/series/risc-v-european-summit-2023.md
@@ -1,0 +1,7 @@
+---
+title: "OpenHW Group TRISTAN Workshop at the RISC-V European Summit"
+subtitle: Barcelona — 5-9 June 2023
+date: 2023-06-09 
+layout: single
+series: risc-v-european-summit-2023
+---

--- a/content/resources/openhwtv/series/risc-v-european-summit-2023.md
+++ b/content/resources/openhwtv/series/risc-v-european-summit-2023.md
@@ -5,3 +5,5 @@ date: 2023-06-09
 layout: single
 series: risc-v-european-summit-2023
 ---
+
+{{< openhw-tv-series >}}

--- a/content/resources/openhwtv/tristan-workshop-a-quick-introduction-to-core-v-verif.md
+++ b/content/resources/openhwtv/tristan-workshop-a-quick-introduction-to-core-v-verif.md
@@ -1,0 +1,11 @@
+---
+title: "TRISTAN Workshop: A Quick Introduction to CORE-V-VERIF"
+date: 2023-08-01
+season: 4
+episode_title: "TRISTAN Workshop: A Quick Introduction to CORE-V-VERIF"
+---
+
+{{< youtube "N3nQJpZN2_0" >}}
+
+This workshop segment is led by Mario Rodriguez, OpenHW Group Verification
+Engineer, Verification Task Group

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
@@ -1,0 +1,15 @@
+---
+title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 2)"
+date: 2023-06-09
+season: 4
+episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 2)" 
+---
+
+{{< youtube "3r5STMiUq9s" >}}
+
+This workshop segment is led by:
+
+- César Fuguet, Research and Development Engineer, CEA
+- Mario Rodriguez, OpenHW Group Verification Engineer, Verification Task Group
+- Davide Schiavone, OpenHW Group Director of Engineering, Cores Task Group
+- Mike Thompson, OpenHW Group Director of Engineering, Verification Task Group

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
@@ -1,7 +1,7 @@
 ---
 title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 2)"
 date: 2023-06-09
-series: risc-v-european-summit
+series: risc-v-european-summit-2023
 episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 2)" 
 ---
 

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
@@ -1,7 +1,7 @@
 ---
 title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 2)"
 date: 2023-06-09
-season: 4
+series: risc-v-european-summit
 episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 2)" 
 ---
 

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training-part-2.md
@@ -1,6 +1,6 @@
 ---
 title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 2)"
-date: 2023-06-09
+date: 2023-08-01
 series: risc-v-european-summit-2023
 episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 2)" 
 ---

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
@@ -1,7 +1,7 @@
 ---
 title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 1)"
 date: 2023-06-09
-season: 4
+series: risc-v-european-summit
 episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 1)" 
 ---
 

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
@@ -1,7 +1,7 @@
 ---
 title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 1)"
 date: 2023-06-09
-series: risc-v-european-summit
+series: risc-v-european-summit-2023
 episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 1)" 
 ---
 

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
@@ -1,0 +1,15 @@
+---
+title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 1)"
+date: 2023-06-09
+season: 4
+episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 1)" 
+---
+
+{{< youtube "Twihznkd7-U" >}}
+
+This workshop segment is led by:
+
+- César Fuguet, Research and Development Engineer, CEA
+- Mario Rodriguez, OpenHW Group Verification Engineer, Verification Task Group
+- Davide Schiavone, OpenHW Group Director of Engineering, Cores Task Group
+- Mike Thompson, OpenHW Group Director of Engineering, Verification Task Group

--- a/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
+++ b/content/resources/openhwtv/tristan-workshop-open-source-hardware-basic-training.md
@@ -1,6 +1,6 @@
 ---
 title: "TRISTAN Workshop: Open Source Hardware Basic Training (Part 1)"
-date: 2023-06-09
+date: 2023-08-01
 series: risc-v-european-summit-2023
 episode_title: "TRISTAN Workshop: Open-Source Hardware Basic Training (Part 1)" 
 ---

--- a/content/resources/openhwtv/tristan-workshop-simulating-cv32e40p-in-core-v-verif.md
+++ b/content/resources/openhwtv/tristan-workshop-simulating-cv32e40p-in-core-v-verif.md
@@ -1,7 +1,7 @@
 ---
 title: "TRISTAN Workshop: Simulating CV32E40P in CORE-V-VERIF"
 date: 2023-08-01
-season: 4
+series: risc-v-european-summit-2023
 episode_title: "TRISTAN Workshop: Simulating CV32E40P in CORE-V-VERIF" 
 ---
 

--- a/content/resources/openhwtv/tristan-workshop-simulating-cv32e40p-in-core-v-verif.md
+++ b/content/resources/openhwtv/tristan-workshop-simulating-cv32e40p-in-core-v-verif.md
@@ -1,0 +1,11 @@
+---
+title: "TRISTAN Workshop: Simulating CV32E40P in CORE-V-VERIF"
+date: 2023-08-01
+season: 4
+episode_title: "TRISTAN Workshop: Simulating CV32E40P in CORE-V-VERIF" 
+---
+
+{{< youtube "nGs6riKUZLU" >}}
+
+This workshop segment is led by Mike Thompson, OpenHW Group Director of
+Engineering, Verification Task Group

--- a/content/resources/openhwtv/tristan-workshop-simulating-cva6-in-core-v-verif.md
+++ b/content/resources/openhwtv/tristan-workshop-simulating-cva6-in-core-v-verif.md
@@ -1,11 +1,11 @@
 ---
-title: "TRISTAN Workshop: A Quick Introduction to CORE-V-VERIF"
+title: "TRISTAN Workshop: Simulating CVA6 in CORE-V-VERIF"
 date: 2023-08-01
 series: risc-v-european-summit-2023
-episode_title: "TRISTAN Workshop: A Quick Introduction to CORE-V-VERIF"
+episode_title: "TRISTAN Workshop: Simulating CVA6 in CORE-V-VERIF" 
 ---
 
-{{< youtube "N3nQJpZN2_0" >}}
+{{< youtube "8p7TMX4GPmo" >}}
 
 This workshop segment is led by Mario Rodriguez, OpenHW Group Verification
 Engineer, Verification Task Group

--- a/layouts/shortcodes/openhw-tv-series.html
+++ b/layouts/shortcodes/openhw-tv-series.html
@@ -3,7 +3,7 @@
 {{ $seriesLocation := .Get "seriesSection" | default .Site.Params.openhw_tv_series_location | default "/resources/openhwtv/series/" }}
 {{ $seriesSection := .Site.GetPage "section" $seriesLocation }}
 
-<!-- Get the series with the most recent date -->
+<!-- Get the series page with the most recent date -->
 {{ $latestSeriesKey := "" }}
 {{ range first 1 ((where $videosSection.RegularPages "Params.series" "!=" "").ByDate.Reverse)  }}
   {{ $latestSeriesKey = .Params.series }} 
@@ -16,13 +16,16 @@
   <small>{{ $latestSeries.Params.subtitle }}</small>
 </h2>
 
-{{ $seriesVideos := where $videosSection.RegularPages "Params.series" "==" $latestSeriesKey }}
-{{ range $seriesVideos }}
-  <div class="openhw-tv-item col-xs-24 col-sm-12 margin-bottom-20">
-    <h3>{{ .Title }}</h3>
-    {{- with .Params.episode_title }}<h4>{{ . }}</h4> {{ end -}}
-    <p>{{ dateFormat "Jan 2, 2006" .Date }}</p>
-    {{ .Content }}
-  </div>
-{{ end }}
+<div class="row">
+  <!-- Get all video pages which fall under the latest series -->
+  {{ $seriesVideos := where $videosSection.RegularPages "Params.series" "==" $latestSeriesKey }}
+  {{ range $seriesVideos }}
+    <div class="openhw-tv-item col-xs-24 col-sm-12 margin-bottom-20">
+      <h3>{{ .Title }}</h3>
+      {{- with .Params.episode_title }}<h4>{{ . }}</h4> {{ end -}}
+      <p>{{ dateFormat "Jan 2, 2006" .Date }}</p>
+      {{ .Content }}
+    </div>
+  {{ end }}
+</div>
 

--- a/layouts/shortcodes/openhw-tv-series.html
+++ b/layouts/shortcodes/openhw-tv-series.html
@@ -1,0 +1,28 @@
+{{ $videosLocation := .Get "videosSection" | default .Site.Params.openhw_tv_section | default "/resources/openhwtv/_index.md" }}
+{{ $videosSection := .Site.GetPage "section" $videosLocation }}
+{{ $seriesLocation := .Get "seriesSection" | default .Site.Params.openhw_tv_series_location | default "/resources/openhwtv/series/" }}
+{{ $seriesSection := .Site.GetPage "section" $seriesLocation }}
+
+<!-- Get the series with the most recent date -->
+{{ $latestSeriesKey := "" }}
+{{ range first 1 ((where $videosSection.RegularPages "Params.series" "!=" "").ByDate.Reverse)  }}
+  {{ $latestSeriesKey = .Params.series }} 
+{{ end }}
+{{ $latestSeries := index (where $seriesSection.RegularPages "Params.series" "==" $latestSeriesKey) 0 }}
+
+<h2>
+  {{ $latestSeries.Title }}
+  <br />
+  <small>{{ $latestSeries.Params.subtitle }}</small>
+</h2>
+
+{{ $seriesVideos := where $videosSection.RegularPages "Params.series" "==" $latestSeriesKey }}
+{{ range $seriesVideos }}
+  <div class="openhw-tv-item col-xs-24 col-sm-12 margin-bottom-20">
+    <h3>{{ .Title }}</h3>
+    {{- with .Params.episode_title }}<h4>{{ . }}</h4> {{ end -}}
+    <p>{{ dateFormat "Jan 2, 2006" .Date }}</p>
+    {{ .Content }}
+  </div>
+{{ end }}
+

--- a/layouts/shortcodes/openhw-tv-series.html
+++ b/layouts/shortcodes/openhw-tv-series.html
@@ -1,25 +1,25 @@
-{{ $videosLocation := .Get "videosSection" | default .Site.Params.openhw_tv_section | default "/resources/openhwtv/_index.md" }}
-{{ $videosSection := .Site.GetPage "section" $videosLocation }}
-{{ $seriesLocation := .Get "seriesSection" | default .Site.Params.openhw_tv_series_location | default "/resources/openhwtv/series/" }}
-{{ $seriesSection := .Site.GetPage "section" $seriesLocation }}
+{{ $videos_location := .Get "videosSection" | default .Site.Params.openhw_tv_section | default "/resources/openhwtv/_index.md" }}
+{{ $videos_section := .Site.GetPage "section" $videos_location }}
+{{ $series_location := .Get "seriesSection" | default .Site.Params.openhw_tv_series_location | default "/resources/openhwtv/series/" }}
+{{ $series_section := .Site.GetPage "section" $series_location }}
 
 <!-- Get the series page with the most recent date -->
-{{ $latestSeriesKey := "" }}
-{{ range first 1 ((where $videosSection.RegularPages "Params.series" "!=" "").ByDate.Reverse)  }}
-  {{ $latestSeriesKey = .Params.series }} 
+{{ $latest_series_key := "" }}
+{{ range first 1 ((where $videos_section.RegularPages "Params.series" "!=" "").ByDate.Reverse)  }}
+  {{ $latest_series_key = .Params.series }} 
 {{ end }}
-{{ $latestSeries := index (where $seriesSection.RegularPages "Params.series" "==" $latestSeriesKey) 0 }}
+{{ $latest_series := index (where $series_section.RegularPages "Params.series" "==" $latest_series_key) 0 }}
 
 <h2>
-  {{ $latestSeries.Title }}
+  {{ $latest_series.Title }}
   <br />
-  <small>{{ $latestSeries.Params.subtitle }}</small>
+  <small>{{ $latest_series.Params.subtitle }}</small>
 </h2>
 
 <div class="row">
   <!-- Get all video pages which fall under the latest series -->
-  {{ $seriesVideos := where $videosSection.RegularPages "Params.series" "==" $latestSeriesKey }}
-  {{ range $seriesVideos }}
+  {{ $series_videos := where $videos_section.RegularPages "Params.series" "==" $latest_series_key }}
+  {{ range $series_videos }}
     <div class="openhw-tv-item col-xs-24 col-sm-12 margin-bottom-20">
       <h3>{{ .Title }}</h3>
       {{- with .Params.episode_title }}<h4>{{ . }}</h4> {{ end -}}

--- a/layouts/shortcodes/openhw-tv-videos.html
+++ b/layouts/shortcodes/openhw-tv-videos.html
@@ -13,7 +13,9 @@
 {{ $.Scratch.Set "counter" 0}}
 {{ $videosLocation := .Get "videosSection" | default .Site.Params.openhw_tv_section | default "/resources/openhwtv/_index.md" }}
 {{ $seasonsLocation := .Get "seasonsSection" | default .Site.Params.openhw_tv_seasons_location | default "/resources/openhwtv/seasons/" }}
+{{ $seriesLocation := .Get "seriesSection" | default .Site.Params.openhw_tv_series_location | default "/resources/openhwtv/series/" }}
 {{ $videosSection := .Site.GetPage "section" $videosLocation }}
+{{ $seriesSection := .Site.GetPage "section" $seriesLocation }}
 {{ $displayArchiveButtons := .Get "displayArchive" | default "false" }}
 
 {{ $seasons := sort ($videosSection.Pages.GroupByParam "season") "Key" "desc"}}
@@ -55,3 +57,21 @@
   {{ end }}
 </div>
 {{ end }}
+
+<!-- Get the series with the most recent date -->
+{{ $latestSeriesKey := "" }}
+{{ range first 1 ((where $videosSection.RegularPages "Params.series" "!=" "").ByDate.Reverse)  }}
+  {{ $latestSeriesKey = .Params.series }} 
+{{ end }}
+{{ $latestSeries := index (where $seriesSection.RegularPages "Params.series" "==" $latestSeriesKey) 0 }}
+
+<hr class="margin-top-60 margin-bottom-40" />
+
+<h2>
+  {{ $latestSeries.Title }}
+  <br />
+  <small>{{ $latestSeries.Params.subtitle }}</small>
+</h2>
+
+
+

--- a/layouts/shortcodes/openhw-tv-videos.html
+++ b/layouts/shortcodes/openhw-tv-videos.html
@@ -13,9 +13,7 @@
 {{ $.Scratch.Set "counter" 0}}
 {{ $videosLocation := .Get "videosSection" | default .Site.Params.openhw_tv_section | default "/resources/openhwtv/_index.md" }}
 {{ $seasonsLocation := .Get "seasonsSection" | default .Site.Params.openhw_tv_seasons_location | default "/resources/openhwtv/seasons/" }}
-{{ $seriesLocation := .Get "seriesSection" | default .Site.Params.openhw_tv_series_location | default "/resources/openhwtv/series/" }}
 {{ $videosSection := .Site.GetPage "section" $videosLocation }}
-{{ $seriesSection := .Site.GetPage "section" $seriesLocation }}
 {{ $displayArchiveButtons := .Get "displayArchive" | default "false" }}
 
 {{ $seasons := sort ($videosSection.Pages.GroupByParam "season") "Key" "desc"}}
@@ -57,21 +55,4 @@
   {{ end }}
 </div>
 {{ end }}
-
-<!-- Get the series with the most recent date -->
-{{ $latestSeriesKey := "" }}
-{{ range first 1 ((where $videosSection.RegularPages "Params.series" "!=" "").ByDate.Reverse)  }}
-  {{ $latestSeriesKey = .Params.series }} 
-{{ end }}
-{{ $latestSeries := index (where $seriesSection.RegularPages "Params.series" "==" $latestSeriesKey) 0 }}
-
-<hr class="margin-top-60 margin-bottom-40" />
-
-<h2>
-  {{ $latestSeries.Title }}
-  <br />
-  <small>{{ $latestSeries.Params.subtitle }}</small>
-</h2>
-
-
 


### PR DESCRIPTION
Resolves #639 

This change allows for a collection of videos to be displayed which do not belong to an OpenHW TV season.

It will only display the collection whose the most recent. The most recent collection is determined by it's newest video's date.

The /resources/openhwtv/series route is not linked anywhere as of yet. I believe it would be best for it to be linked once multiple collections exist.