### PR TITLE
feat: Update task groups

### DIFF
--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -9,10 +9,8 @@ groups:
         company: Thales Group
         position: Co-chair
         linkedin: https://www.linkedin.com/in/j%C3%A9r%C3%B4me-qu%C3%A9vremont-245335/?originalSubdomain=fr
-      - name: David Lynch
-        company: CMC Microsystems
+      - name: Vacant Position 
         position: Co-Chair
-        linkedin: https://www.linkedin.com/in/david-lynch-3514474/
     task_groups:
       - name: Cores Task Group
         mailingList: OpenHW CORE-V Cores Mailing List here

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -7,10 +7,10 @@ groups:
     chairs:
       - name: Jérôme Quevremont
         company: Thales Group
-        position: Co-chair
+        position: Co Chair
         linkedin: https://www.linkedin.com/in/j%C3%A9r%C3%B4me-qu%C3%A9vremont-245335/?originalSubdomain=fr
       - name: Vacant Position 
-        position: Co-Chair
+        position: Co Chair
     task_groups:
       - name: Cores Task Group
         mailingList: OpenHW CORE-V Cores Mailing List here
@@ -36,7 +36,7 @@ groups:
             position: Chair
           - name: Jean-Roch Coulon
             company: Thales Group
-            position: Co-Chair
+            position: Co Chair
             linkedin: https://www.linkedin.com/in/jeanrochcoulon/?originalSubdomain=fr
       - name: SW Task Group
         description: |
@@ -76,11 +76,11 @@ groups:
         chairs:
           - name: Jaume Abella
             company: Barcelona Supercomputer Centre
-            position: Co-Chair
+            position: Co Chair
             linkedin: https://www.linkedin.com/in/jaume-abella-860575/
           - name: Chris Jones
             company: Crypto Quantique
-            position: Co-Chair
+            position: Co Chair
             linkedin: https://www.linkedin.com/in/chris-jones-1791b71/
 
   - name: Marketing Working Group
@@ -91,11 +91,11 @@ groups:
     chairs:
        - name: Brent Jodoin
          company: CMC Microsystems
-         position: Co-chair
+         position: Co Chair
          linkedin: https://www.linkedin.com/in/kdobie/
        - name: Danny Hua
          company: Futurewei Technologies
-         position: Co-chair
+         position: Co Chair
          linkedin: https://www.linkedin.com/in/danny-hua-85186ab/
     task_groups:
       - name: University Outreach Task Group
@@ -104,19 +104,19 @@ groups:
         chairs:
           - name: Mel Chaar
             company: Mitacs
-            position: Co-chair
+            position: Co Chair
             linkedin: https://www.linkedin.com/in/melchaar
           - name: Hugh Pollitt-Smith
             company: CMC Microsystems
-            position: Co-chair
+            position: Co Chair
             linkedin: https://www.linkedin.com/in/hugh-pollitt-smith-460aba3/
       - name: Interconnect Task Group
         chairs:
           - name: Jonathan Balkind
             company: UC Santa Barbara
-            position: Co-Chair
+            position: Co Chair
             linkedin: https://www.linkedin.com/in/jbalkind/
           - name: César Fuguet
             company: CEA
-            position: Co-Chair
+            position: Co Chair
             linkedin: https://www.linkedin.com/in/cesar-fuguet/

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -37,7 +37,7 @@ groups:
             position: Co Chair
             linkedin: https://www.linkedin.com/in/jeanrochcoulon/?originalSubdomain=fr
           - name: Vacant Position 
-            position: Chair
+            position: Co Chair
       - name: SW Task Group
         description: |
           <p>The SW Task Group has the mandate to define, develop and support SW tool chain, operating system ports and firmware for the cores and IP developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">SW Task Group projects can be found here</a>.</p>

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -107,16 +107,3 @@ groups:
          company: Futurewei Technologies
          position: Co Chair
          linkedin: https://www.linkedin.com/in/danny-hua-85186ab/
-    task_groups:
-      - name: University Outreach Task Group
-        description: |
-          <p>The University Outreach Task Group has the mandate to establish industry sponsored research projects and their respective funding (with government matching) in collaboration with leading universities throughout the world.</p>
-        chairs:
-          - name: Mel Chaar
-            company: Mitacs
-            position: Co Chair
-            linkedin: https://www.linkedin.com/in/melchaar
-          - name: Hugh Pollitt-Smith
-            company: CMC Microsystems
-            position: Co Chair
-            linkedin: https://www.linkedin.com/in/hugh-pollitt-smith-460aba3/

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -32,10 +32,8 @@ groups:
         description: |
           <p>The Verification Task Group has the mandate to develop best in class verification test bench environments for the cores and IP blocks developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">Verification Task Group projects can be found here</a>.</p>
         chairs:
-          - name: Simon Davidmann
-            company: Imperas
+          - name: Position Vacant 
             position: Chair
-            linkedin: https://www.linkedin.com/in/simon-davidmann-57656b143/
           - name: Jean-Roch Coulon
             company: Thales Group
             position: Vice Chair

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -64,6 +64,24 @@ groups:
             company: QuickLogic Corporation
             position: Vice Chair
             linkedin: https://www.linkedin.com/in/tim-saxe-aa281a4/
+      - name: Safety and Security Task Group
+        description: |
+          <p>
+            OpenHW Group's Safety and Security TG is the Task Group developing
+            the roadmap for and implementations of Functional Safety and
+            Security IP for OpenHW's cores and ASICs.
+          </p>
+        mailingList: OpenHW CORE-V Safety and Security Mailing List here
+        mailingListAnchor: https://accounts.eclipse.org/mailing-list/openhw.safety-security
+        chairs:
+          - name: Jaume Abella
+            company: Barcelona Supercomputer Centre
+            position: Co-Chair
+            linkedin: https://www.linkedin.com/in/jaume-abella-860575/
+          - name: Chris Jones
+            company: Crypto Quantique
+            position: Co-Chair
+            linkedin: https://www.linkedin.com/in/chris-jones-1791b71/
   - name: Marketing Working Group
     mailingList: OpenHW MWG Mailing List here
     mailingListAnchor: https://accounts.eclipse.org/mailing-list/openhw.mwg

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -44,14 +44,12 @@ groups:
         mailingList: OpenHW CORE-V SW TG Mailing List here
         mailingListAnchor: https://accounts.eclipse.org/mailing-list/openhw.core-v.sw
         chairs:
-          - name: Jeremy Bennett
+          - name: Paolo Savini
             company: Embecosm
             position: Chair
-            linkedin: https://www.linkedin.com/in/jeremypbennett/
-          - name: Yunhai Shang
-            company: Alibaba T-Head
+            linkedin: https://www.linkedin.com/in/paolo-savini-56b833147/
+          - name: Position Vacant 
             position: Vice Chair
-            linkedin: http://www.linkedin.com/in/yunhai-shang/
       - name: HW Task Group
         description: |
           <p>The HW Task Group has the mandate to define, develop and support SoC and FPGA based evaluation / development platforms for the cores and IP developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">HW Task Group projects can be found here</a>.</p>

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -36,7 +36,7 @@ groups:
             position: Chair
           - name: Jean-Roch Coulon
             company: Thales Group
-            position: Vice Chair
+            position: Co-Chair
             linkedin: https://www.linkedin.com/in/jeanrochcoulon/?originalSubdomain=fr
       - name: SW Task Group
         description: |

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -82,6 +82,7 @@ groups:
             company: Crypto Quantique
             position: Co-Chair
             linkedin: https://www.linkedin.com/in/chris-jones-1791b71/
+
   - name: Marketing Working Group
     mailingList: OpenHW MWG Mailing List here
     mailingListAnchor: https://accounts.eclipse.org/mailing-list/openhw.mwg
@@ -109,4 +110,13 @@ groups:
             company: CMC Microsystems
             position: Co-chair
             linkedin: https://www.linkedin.com/in/hugh-pollitt-smith-460aba3/
-          
+      - name: Interconnect Task Group
+        chairs:
+          - name: Jonathan Balkind
+            company: UC Santa Barbara
+            position: Co-Chair
+            linkedin: https://www.linkedin.com/in/jbalkind/
+          - name: César Fuguet
+            company: CEA
+            position: Co-Chair
+            linkedin: https://www.linkedin.com/in/cesar-fuguet/

--- a/data/working_groups.yml
+++ b/data/working_groups.yml
@@ -32,12 +32,12 @@ groups:
         description: |
           <p>The Verification Task Group has the mandate to develop best in class verification test bench environments for the cores and IP blocks developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">Verification Task Group projects can be found here</a>.</p>
         chairs:
-          - name: Position Vacant 
-            position: Chair
           - name: Jean-Roch Coulon
             company: Thales Group
             position: Co Chair
             linkedin: https://www.linkedin.com/in/jeanrochcoulon/?originalSubdomain=fr
+          - name: Vacant Position 
+            position: Chair
       - name: SW Task Group
         description: |
           <p>The SW Task Group has the mandate to define, develop and support SW tool chain, operating system ports and firmware for the cores and IP developed within the OpenHW Group. Existing <a href="https://www.openhwgroup.org/projects/">SW Task Group projects can be found here</a>.</p>
@@ -48,7 +48,7 @@ groups:
             company: Embecosm
             position: Chair
             linkedin: https://www.linkedin.com/in/paolo-savini-56b833147/
-          - name: Position Vacant 
+          - name: Vacant Position
             position: Vice Chair
       - name: HW Task Group
         description: |
@@ -82,6 +82,16 @@ groups:
             company: Crypto Quantique
             position: Co Chair
             linkedin: https://www.linkedin.com/in/chris-jones-1791b71/
+      - name: Interconnect Task Group
+        chairs:
+          - name: Jonathan Balkind
+            company: UC Santa Barbara
+            position: Co Chair
+            linkedin: https://www.linkedin.com/in/jbalkind/
+          - name: César Fuguet
+            company: CEA
+            position: Co Chair
+            linkedin: https://www.linkedin.com/in/cesar-fuguet/
 
   - name: Marketing Working Group
     mailingList: OpenHW MWG Mailing List here
@@ -110,13 +120,3 @@ groups:
             company: CMC Microsystems
             position: Co Chair
             linkedin: https://www.linkedin.com/in/hugh-pollitt-smith-460aba3/
-      - name: Interconnect Task Group
-        chairs:
-          - name: Jonathan Balkind
-            company: UC Santa Barbara
-            position: Co Chair
-            linkedin: https://www.linkedin.com/in/jbalkind/
-          - name: César Fuguet
-            company: CEA
-            position: Co Chair
-            linkedin: https://www.linkedin.com/in/cesar-fuguet/

--- a/layouts/shortcodes/working-groups.html
+++ b/layouts/shortcodes/working-groups.html
@@ -44,35 +44,38 @@
       </div>
       {{ end }}
     </div>
-    <h3>Task groups</h3>
-    {{ range .task_groups }}
-    <div class="task-group margin-bottom-20">
-      <h4 id="{{ .name | urlize }}">{{ .name | title }}</h4>
-      {{ .description | safeHTML }}
-        <div class="container margin-top-30 margin-bottom-50">
-          <div class="row text-center">
-            {{ range .chairs }}
-            <div class="col-xs-24 col-sm-12 match-height-item-row">
-              <p>{{ .name }}</p>
-              <p><strong>{{ .position }}</strong></p>
-              <p><em>{{ .company }}</em></p>
-              {{ if .linkedin }}
-              <p>
-                 <a class="btn btn-primary btn-sm" href="{{ .linkedin }}" target="_blank">
-                   <i class="fa fa-linkedin margin-right-10"></i>&nbsp;Follow {{ .name }} on LinkedIn
-                 </a>
-              </p>
-              {{ end }} 
+    <!-- Render task groups if they exist -->
+    {{ if and (.task_groups) (gt (len .task_groups) 0) }}
+      <h3>Task groups</h3>
+      {{ range .task_groups }}
+      <div class="task-group margin-bottom-20">
+        <h4 id="{{ .name | urlize }}">{{ .name | title }}</h4>
+        {{ .description | safeHTML }}
+          <div class="container margin-top-30 margin-bottom-50">
+            <div class="row text-center">
+              {{ range .chairs }}
+              <div class="col-xs-24 col-sm-12 match-height-item-row">
+                <p>{{ .name }}</p>
+                <p><strong>{{ .position }}</strong></p>
+                <p><em>{{ .company }}</em></p>
+                {{ if .linkedin }}
+                <p>
+                   <a class="btn btn-primary btn-sm" href="{{ .linkedin }}" target="_blank">
+                     <i class="fa fa-linkedin margin-right-10"></i>&nbsp;Follow {{ .name }} on LinkedIn
+                   </a>
+                </p>
+                {{ end }} 
+              </div>
+              {{ end }}
+            </div>
+            {{ if .mailingListAnchor }}
+            <div class="row text-center margin-top-20">
+              <p>You can join the <a href="{{ .mailingListAnchor }}">{{ .mailingList }}</a>.
             </div>
             {{ end }}
           </div>
-          {{ if .mailingListAnchor }}
-          <div class="row text-center margin-top-20">
-            <p>You can join the <a href="{{ .mailingListAnchor }}">{{ .mailingList }}</a>.
-          </div>
-          {{ end }}
-        </div>
-    </div>
+      </div>
+      {{ end }}
     {{ end }}
   </div>
   {{ end }}


### PR DESCRIPTION
Resolves #651 

Updates various positions for the task groups.

It also makes the task group section not render if no task groups exist for a particular WG.