### PR TITLE
fix: capitalization typo

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ headline: "OpenHW Foundation"
 custom_jumbotron: |
   <p class="featured-jumbotron-subtitle">
     The leading global community for <br> Industrial Grade, Open Source RISC-V
-    CPU development and Innovation
+    CPU development and innovation
   </p>
 custom_jumbotron_class: "col-xs-24"
 hide_sidebar : true

--- a/content/_index.md
+++ b/content/_index.md
@@ -2,7 +2,12 @@
 title: "Home"
 seo_title: "OpenHW Group"
 headline: "OpenHW Foundation"
-subtitle: "The leading global community for <br> Industrial Grade, Open Source RISC-V CPU development and Innovation"
+custom_jumbotron: |
+  <p class="featured-jumbotron-subtitle">
+    The leading global community for <br> Industrial Grade, Open Source RISC-V
+    CPU development and Innovation
+  </p>
+custom_jumbotron_class: "col-xs-24"
 hide_sidebar : true
 hide_page_title: true
 hide_breadcrumb: true


### PR DESCRIPTION
Using `custom_jumbotron` instead of `subtitle` so we can avoid text capitalization that happens with the jumbotron partial.